### PR TITLE
feat: Add possibility to pass in additional _to_ commit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ function cli(): void {
 
   const baseRevision = opts.baseRevision;
   const topReviewers = handleAppErrors(
-    () => gitSuggestReviewer(baseRevision),
+    () => gitSuggestReviewer(baseRevision, opts.toRevision),
     opts.verbose
   );
 
@@ -48,6 +48,7 @@ Suggest candidates for a code review based on git history.
 USAGE:
   git-suggest-reviewers [OPTIONS]
   git-suggest-reviewers [OPTIONS] base_revision
+  git-suggest-reviewers [OPTIONS] <commit> <commit>
 
 Options:
     -h --help        Show this help
@@ -61,6 +62,7 @@ Options:
 
 interface CliOptions {
   baseRevision?: string;
+  toRevision?: string;
   help: boolean;
   version: boolean;
   verbose: boolean;
@@ -102,6 +104,8 @@ function parseArgs(args: Array<string>): undefined | CliOptions {
       default:
         if (!arg.startsWith('-') && !options.baseRevision) {
           options.baseRevision = arg;
+        } else if (!arg.startsWith('-') && !options.toRevision) {
+          options.toRevision = arg;
         } else {
           console.warn('Invalid argument: ' + arg);
         }

--- a/src/core.ts
+++ b/src/core.ts
@@ -18,9 +18,12 @@ import {lines} from './utils';
  * This exception is thrown on unknown/unhandled errors. This is considered a
  * bug.
  */
-export function gitSuggestReviewer(baseRevision: string): SuggestedReviewers {
+export function gitSuggestReviewer(
+  baseRevision: string,
+  toRevision?: string
+): SuggestedReviewers {
   try {
-    return gitSuggestReviewerUnsafe(baseRevision);
+    return gitSuggestReviewerUnsafe(baseRevision, toRevision);
   } catch (error: unknown) {
     if (
       error instanceof Error &&
@@ -35,8 +38,11 @@ export function gitSuggestReviewer(baseRevision: string): SuggestedReviewers {
   }
 }
 
-function gitSuggestReviewerUnsafe(baseRevision: string): SuggestedReviewers {
-  const diff = gitDiff(baseRevision);
+function gitSuggestReviewerUnsafe(
+  baseRevision: string,
+  toRevision?: string
+): SuggestedReviewers {
+  const diff = gitDiff(baseRevision, toRevision);
   const diffChanges = getDiffChanges(diff);
   const diffBlames = collectBlames(baseRevision, diffChanges);
   const diffBlameInfo = collectBlameInfo(diffBlames);

--- a/src/git-cmds.ts
+++ b/src/git-cmds.ts
@@ -17,8 +17,11 @@ export function gitBlame(
   ]);
 }
 
-export function gitDiff(baseRevision: string): string {
-  return runGitCmd('diff', [baseRevision]);
+export function gitDiff(baseRevision: string, toRevision?: string): string {
+  return runGitCmd(
+    'diff',
+    [baseRevision].concat(toRevision ? [toRevision] : [])
+  );
 }
 
 function runGitCmd(cmd: SupportedGitCmd, opts: Array<string>): string {

--- a/test/e2e/__snapshots__/e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/e2e.test.ts.snap
@@ -8,6 +8,7 @@ Suggest candidates for a code review based on git history.
 USAGE:
   git-suggest-reviewers [OPTIONS]
   git-suggest-reviewers [OPTIONS] base_revision
+  git-suggest-reviewers [OPTIONS] <commit> <commit>
 
 Options:
     -h --help        Show this help
@@ -26,6 +27,7 @@ Suggest candidates for a code review based on git history.
 USAGE:
   git-suggest-reviewers [OPTIONS]
   git-suggest-reviewers [OPTIONS] base_revision
+  git-suggest-reviewers [OPTIONS] <commit> <commit>
 
 Options:
     -h --help        Show this help


### PR DESCRIPTION
`git-suggest-reviewer commit1 commit2` will suggest reviewers for the changes made from commit1 to commit2. `git-suggest-reviewer commit HEAD` is equivalent to running `git-suggest-reviewer commit`.